### PR TITLE
Corrigir apenas o nome da aba "Contrato de carteira" para "imóveis de…

### DIFF
--- a/IrisGestao/IrisApi/IrisInfra/Repository/Impl/ContratoAluguelRepository.cs
+++ b/IrisGestao/IrisApi/IrisInfra/Repository/Impl/ContratoAluguelRepository.cs
@@ -58,10 +58,15 @@ public class ContratoAluguelRepository: Repository<ContratoAluguel>, IContratoAl
                             ExibirAlertaVencimento          = (x.DataFimContrato - DateTime.Now).Days <= 90 ? true : false,
                             IndiceReajuste = x.IdIndiceReajusteNavigation == null ? null : new
                             {
-                                Id                          = x.IdIndiceReajusteNavigation.Id,
-                                Nome                        = x.IdIndiceReajusteNavigation.Nome,
-                                Percentual                  = x.IdIndiceReajusteNavigation.Percentual,
-                                DataAtualizacao             = x.IdIndiceReajusteNavigation.DataAtualizacao
+                                Id = x.IdIndiceReajusteNavigation.Id,
+                                Nome = x.IdIndiceReajusteNavigation.Nome,
+                                Percentual = x.IdIndiceReajusteNavigation.Percentual,
+                                DataAtualizacao = x.IdIndiceReajusteNavigation.DataAtualizacao
+                            },
+                            TipoContrato = x.IdTipoContratoNavigation == null ? null : new
+                            {
+                                Id = x.IdTipoContratoNavigation.Id,
+                                Nome = x.IdTipoContratoNavigation.Nome
                             },
                             CreditoAluguel = x.IdTipoCreditoAluguelNavigation == null ? null : new
                             {

--- a/IrisGestao/IrisSpa/src/app/layout/logged-in/topbar/topbar.component.ts
+++ b/IrisGestao/IrisSpa/src/app/layout/logged-in/topbar/topbar.component.ts
@@ -54,7 +54,7 @@ export class TopbarComponent {
 						command: () => this.navigateTo('property/mercado/listing'),
 					},
 					{
-						label: 'Contrato de carteira',
+						label: 'Imóvel de carteira',
 						id: route.startsWith('property/carteira/') ? 'current' : '',
 						command: () => this.navigateTo('property/carteira/listing'),
 					},

--- a/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-edit/rent-contract-edit.component.html
+++ b/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-edit/rent-contract-edit.component.html
@@ -168,14 +168,12 @@
 								</div>
 
 								<div class="field">
-									<label for="contract-types" class="block"
+									<label for="contractType" class="block"
 										>Tipo de contrato</label
 									>
 									<p-dropdown
 										id="contract-types"
 										[options]="contractTypes"
-										[filter]="true"
-										filterBy="label"
 										formControlName="contractType"
 										aria-describedby="contract-types-help"
 									></p-dropdown>

--- a/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-edit/rent-contract-edit.component.ts
+++ b/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-edit/rent-contract-edit.component.ts
@@ -181,13 +181,13 @@ export class RentContractEditComponent {
 */
 					this.data = event.data[0];
 
-					console.log('>>>', this.data);
+					console.log('Contrato Aluguel >>>', this.data);
 
 					this.imovel = this.data.imovelAlugado[0];
 
 					this.editForm.controls['contractInfo'].patchValue({
 						name: this.data.numeroContrato,
-						contractType: null,
+						contractType: this.data.tipoContrato.id,
 						startDate: new Date(this.data.dataInicioContrato),
 						endDate: new Date(this.data.dataFimContrato),
 						dueDate: this.data.diaVencimentoAluguel,
@@ -214,6 +214,7 @@ export class RentContractEditComponent {
 						rentGrace: this.data.carenciaAluguel,
 						gracePeriod: this.data.prazoCarencia,
 						creditTo: this.data.creditoAluguel.id,
+						prazoDesconto: this.data.prazoDesconto,
 					});
 
 					this.propertyGuid = this.data.imovelAlugado[0].guidReferencia;

--- a/IrisGestao/IrisSpa/src/app/pages/supplier-contract/supplier-contract-edit/supplier-contract-edit.component.html
+++ b/IrisGestao/IrisSpa/src/app/pages/supplier-contract/supplier-contract-edit/supplier-contract-edit.component.html
@@ -282,29 +282,32 @@
 					</div>
 
 					<div class="field">
-						<label for="due-date" class="block">
-							Data do vencimento da parcela
+						<label for="dataVencimentoPrimeraParcela" class="block">
+							Vencimento da primeira parcela
 						</label>
-						<p-dropdown
-							id="due-date"
-							[options]="dueDates"
-							formControlName="dueDate"
-							aria-describedby="due-date-help"
-						></p-dropdown>
-						<ng-container *ngIf="checkHasError(contractInfo['dueDate'])">
+						<p-calendar
+							id="dataVencimentoPrimeraParcela"
+							formControlName="dataVencimentoPrimeraParcela"
+							dateFormat="dd/mm/yy"
+							(onInput)="onInputDate($event)"
+							(onBlur)="onBlurDate()"
+							placeholder="dd/mm/aaaa"
+							aria-describedby="dataVencimentoPrimeraParcela-help"
+						></p-calendar>
+						<ng-container *ngIf="checkHasError(contractInfo['dataVencimentoPrimeraParcela'])">
 							<small
-								id="due-date-help"
+								id="start-date-help"
 								*ngIf="
-									contractInfo['dueDate'].hasError('required');
+									contractInfo['dataVencimentoPrimeraParcela'].hasError('required');
 									else error2
 								"
 								class="p-error block"
 							>
-								Informe a data do vencimento
+							Informe a data de vencimento
 							</small>
 							<ng-template #error2>
-								<small id="due-date-help" class="p-error block">
-									Data do vencimento inválida
+								<small id="start-date-help" class="p-error block">
+									data de vencimento inválida
 								</small>
 							</ng-template>
 						</ng-container>

--- a/IrisGestao/IrisSpa/src/app/pages/supplier-contract/supplier-contract-edit/supplier-contract-edit.component.ts
+++ b/IrisGestao/IrisSpa/src/app/pages/supplier-contract/supplier-contract-edit/supplier-contract-edit.component.ts
@@ -110,7 +110,7 @@ export class SupplierContractEditComponent {
 			serviceValue: ['', Validators.required],
 			startDate: [null, [Validators.required]],
 			endDate: [null, [Validators.required]],
-			dueDate: [null, [Validators.required]],
+			dataVencimentoPrimeraParcela: [null, [Validators.required]],
 			contractIndex: [null, Validators.required],
 			periodicidade: ['', [Validators.required]],
 		});
@@ -149,7 +149,7 @@ export class SupplierContractEditComponent {
 						serviceValue: this.data.valorServicoContratado,
 						startDate: new Date(this.data.dataInicioContrato),
 						endDate: new Date(this.data.dataFimContrato),
-						dueDate: this.data.diaPagamento,
+						dataVencimentoPrimeraParcela: new Date(this.data.dataVencimentoPrimeraParcela),
 						contractIndex: this.data.indiceReajuste.id,
 						periodicidade: this.data.periodicidadeReajuste, //??
 					});
@@ -280,7 +280,7 @@ export class SupplierContractEditComponent {
 			serviceValue: string;
 			startDate: string;
 			endDate: string;
-			dueDate: number;
+			dataVencimentoPrimeraParcela: string;
 			contractIndex: number;
 			periodicidade: string;
 		} = this.editForm.getRawValue();
@@ -300,7 +300,7 @@ export class SupplierContractEditComponent {
 			valorServicoContratado: +formData.serviceValue,
 			dataInicioContrato: formData.startDate,
 			dataFimContrato: formData.endDate,
-			diaPagamento: formData.dueDate,
+			dataVencimentoPrimeraParcela: formData.dataVencimentoPrimeraParcela,
 			periodicidadeReajuste: +formData.periodicidade,
 		};
 


### PR DESCRIPTION
… carteira"

1.   Anexos maiores de 1MB estão sendo salvos, mas a mensagem de erro está sendo apresentada ao anexá-los.

4. Ao finalizar após os anexos, o sistema apresenta o seguinte erro:

Editar contrato já cadastrado:
4.   Faltou o campo para editar o nome do contrato.