### PR TITLE
Ajuste cadastro de unidade 

### DIFF
--- a/IrisGestao/IrisApi/IrisDomain/Entity/Unidade.cs
+++ b/IrisGestao/IrisApi/IrisDomain/Entity/Unidade.cs
@@ -16,13 +16,13 @@ public partial class Unidade: BaseEntity<Unidade>
     [Unicode(false)]
     public string Tipo { get; set; } = null!;
 
-    [Column(TypeName = "decimal(18, 0)")]
+    [Column(TypeName = "decimal(18, 2)")]
     public decimal? AreaUtil { get; set; } = null!;
 
-    [Column(TypeName = "decimal(18, 0)")]
+    [Column(TypeName = "decimal(18, 2)")]
     public decimal? AreaTotal { get; set; } = null!;
 
-    [Column(TypeName = "decimal(18, 0)")]
+    [Column(TypeName = "decimal(18, 2)")]
     public decimal? AreaHabitese { get; set; } = null!;
 
     [StringLength(50)]

--- a/IrisGestao/IrisSpa/src/app/pages/property/unit-edit/unit-edit.component.html
+++ b/IrisGestao/IrisSpa/src/app/pages/property/unit-edit/unit-edit.component.html
@@ -49,7 +49,7 @@
 					<img
 						*ngIf="attachmentsObj"
 						[src]="
-							propertyAttachments.capa?.local ??
+							propertyAttachments?.capa?.local ??
 							'assets/images/imovel-placeholder.png'
 						"
 						alt="property-photo"


### PR DESCRIPTION
O sistema está arredondando todas as áreas Úteis e Totais das unidades dentro dos imóveis.


ALTER TABLE [dbo].[Unidade] ALTER COLUMN [AreaUtil] decimal(18,2) NULL; 
ALTER TABLE [dbo].[Unidade] ALTER COLUMN [AreaTotal] decimal(18,2) NULL; 
ALTER TABLE [dbo].[Unidade] ALTER COLUMN [AreaHabitese] decimal(18,2) NULL;