### PR TITLE
Ajustes Feedback Contrato de aluguel Preenchimento de Valores

### DIFF
--- a/IrisGestao/IrisApi/IrisAppService/Service/Impl/ContratoAluguelService.cs
+++ b/IrisGestao/IrisApi/IrisAppService/Service/Impl/ContratoAluguelService.cs
@@ -516,10 +516,12 @@ public class ContratoAluguelService: IContratoAluguelService
                 ContratoAluguel.GuidReferencia = Guid.NewGuid();
                 ContratoAluguel.DataCriacao = DateTime.Now;
                 ContratoAluguel.DataUltimaModificacao = DateTime.Now;
+                ContratoAluguel.DataFimContrato = cmd.DataInicioContrato.AddMonths(cmd.PrazoTotalContrato);
                 break;
             default:
                 ContratoAluguel.GuidReferencia = ContratoAluguel.GuidReferencia;
                 ContratoAluguel.DataUltimaModificacao = DateTime.Now;
+                ContratoAluguel.DataFimContrato = cmd.DataVencimentoContrato.HasValue ? cmd.DataVencimentoContrato.Value : ContratoAluguel.DataFimContrato;
                 break;
         }
         ContratoAluguel.IdCliente                       = ContratoAluguel.Id;
@@ -538,7 +540,6 @@ public class ContratoAluguelService: IContratoAluguelService
         ContratoAluguel.PrazoCarencia                   = cmd.PrazoCarencia;
         ContratoAluguel.DataInicioContrato              = cmd.DataInicioContrato;
         ContratoAluguel.PrazoTotalContrato              = cmd.PrazoTotalContrato;
-        ContratoAluguel.DataFimContrato                 = cmd.DataInicioContrato.AddMonths(cmd.PrazoTotalContrato);
         ContratoAluguel.DataOcupacao                    = cmd.DataOcupacao;
         ContratoAluguel.DiaVencimentoAluguel            = cmd.DataVencimentoPrimeraParcela.HasValue ? cmd.DataVencimentoPrimeraParcela.Value.Day : 1;
         ContratoAluguel.PeriodicidadeReajuste           = cmd.PeriodicidadeReajuste;

--- a/IrisGestao/IrisApi/IrisAppService/Service/Impl/TituloReceberService.cs
+++ b/IrisGestao/IrisApi/IrisAppService/Service/Impl/TituloReceberService.cs
@@ -6,6 +6,7 @@ using IrisGestao.Domain.Emuns;
 using IrisGestao.Domain.Entity;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using System.Net.NetworkInformation;
 using System.Security.Cryptography;
 
@@ -324,11 +325,11 @@ public class TituloReceberService: ITituloReceberService
         tituloReceber.IdCliente = contratoAluguel?.IdCliente;
         tituloReceber.IdIndiceReajuste = contratoAluguel?.IdIndiceReajuste;
         tituloReceber.IdTipoCreditoAluguel = contratoAluguel?.IdTipoCreditoAluguel;
-        tituloReceber.ValorTitulo = contratoAluguel.ValorAluguel as decimal?;
-        tituloReceber.ValorTotalTitulo = contratoAluguel.ValorAluguelLiquido as decimal?;
+        tituloReceber.ValorTitulo = Convert.ToDecimal(contratoAluguel.ValorAluguel);
+        tituloReceber.ValorTotalTitulo = Convert.ToDecimal(contratoAluguel.ValorAluguelLiquido);
         tituloReceber.Parcelas = prazo;
         tituloReceber.DataVencimentoPrimeraParcela = contratoAluguel.DataVencimentoPrimeraParcela;
-        tituloReceber.PorcentagemTaxaAdministracao = contratoAluguel.PercentualRetencaoImpostos as decimal?;
+        tituloReceber.PorcentagemTaxaAdministracao = Convert.ToDecimal(contratoAluguel.PercentualRetencaoImpostos);
 
         BindFaturaTituloByContratoAluguelData(contratoAluguel, tituloReceber, lstFaturaTitulo);
     }
@@ -336,6 +337,7 @@ public class TituloReceberService: ITituloReceberService
     private static List<FaturaTitulo> BindFaturaTituloByContratoAluguelData(ContratoAluguel contratoAluguel, TituloReceber tituloReceber, List<FaturaTitulo> lstFaturaTitulo)
     {
         int contaDesconto = 1;
+        decimal valorFatura;
         for (int i = 0; i < contratoAluguel.PrazoTotalContrato; i++)
         {
             if (i > 11)
@@ -361,7 +363,7 @@ public class TituloReceberService: ITituloReceberService
 
             DateTime dataVencimento = tituloReceber.DataVencimentoPrimeraParcela.Value.AddMonths(i);
             int diaVencimento = tituloReceber.DataVencimentoPrimeraParcela.Value.Day > 28 ? 28 : dataVencimento.Day;
-
+            //Decimal.TryParse(ValorAPagar, out valorFatura);
             FaturaTitulo faturaTitulo           = new FaturaTitulo();
             faturaTitulo.StatusFatura           = FaturaTituloEnum.A_VENCER;
             faturaTitulo.NumeroParcela          = i+1;
@@ -370,7 +372,7 @@ public class TituloReceberService: ITituloReceberService
             faturaTitulo.DataUltimaModificacao  = DateTime.Now;
             faturaTitulo.GuidReferencia         = Guid.NewGuid();
             faturaTitulo.NumeroFatura           = tituloReceber.NumeroTitulo + "/" + (i+1).ToString("D2");
-            faturaTitulo.Valor                  = ValorAPagar as decimal?;
+            faturaTitulo.Valor                  = Convert.ToDecimal(ValorAPagar);
             faturaTitulo.DataVencimento         = new DateTime(dataVencimento.Year, dataVencimento.Month, diaVencimento);
 
             lstFaturaTitulo.Add(faturaTitulo);
@@ -407,10 +409,10 @@ public class TituloReceberService: ITituloReceberService
         tituloReceber.IdIndiceReajuste                  = cmd.IdIndiceReajuste;
         tituloReceber.IdTipoCreditoAluguel              = cmd.IdTipoCreditoAluguel;
         tituloReceber.IdFormaPagamento                  = cmd.IdFormaPagamento;
-        tituloReceber.ValorTitulo                       = valorLiquido as decimal?;
-        tituloReceber.ValorTotalTitulo                  = (valorLiquido * cmd.Parcelas) as decimal?;
+        tituloReceber.ValorTitulo                       = Convert.ToDecimal(valorLiquido);
+        tituloReceber.ValorTotalTitulo                  = Convert.ToDecimal(valorLiquido * cmd.Parcelas);
         tituloReceber.Parcelas                          = cmd.Parcelas;
-        tituloReceber.PorcentagemTaxaAdministracao      = cmd.PorcentagemImpostoRetido as decimal?;
+        tituloReceber.PorcentagemTaxaAdministracao      = Convert.ToDecimal(cmd.PorcentagemImpostoRetido);
 
         if(criacao)
             BindFaturaTituloData(tituloReceber, lstFaturaTitulo);

--- a/IrisGestao/IrisApi/IrisDomain/Command/Request/CriarContratoAluguelCommand.cs
+++ b/IrisGestao/IrisApi/IrisDomain/Command/Request/CriarContratoAluguelCommand.cs
@@ -24,6 +24,7 @@ namespace IrisGestao.Domain.Command.Request
         public int? PrazoCarencia { get; set; }
         public DateTime DataInicioContrato { get; set; }
         public DateTime? DataVencimentoPrimeraParcela { get; set; }
+        public DateTime? DataVencimentoContrato { get; set; }
         public int PrazoTotalContrato { get; set; }
         public DateTime? DataOcupacao { get; set; }
         public int DiaVencimentoAluguel { get; set; }

--- a/IrisGestao/IrisSpa/src/app/pages/property/property-view/property-view.component.html
+++ b/IrisGestao/IrisSpa/src/app/pages/property/property-view/property-view.component.html
@@ -204,13 +204,24 @@
 						<li *ngFor="let unit of units.slice(0, unitListAmount)">
 							<div class="unitCard">
 								<div class="tags">
-									<p-tag
-										value="Unidade disponível"
-										[rounded]="true"
-										severity="success"
-										styleClass="w-36"
-									></p-tag>
+									<ng-container *ngIf="unit.unidadeLocada; else disponivel">
+										<p-tag
+											value="Unidade locada"
+											[rounded]="true"
+											severity="danger"
+											styleClass="w-36"
+										></p-tag>
+									</ng-container>
+									<ng-template #disponivel>
+										<p-tag
+											value="Unidade disponível"
+											[rounded]="true"
+											severity="success"
+											styleClass="w-36"
+										></p-tag>
+									</ng-template>
 								</div>
+								
 								<header>
 									<h4>{{ unit.tipo }}</h4>
 

--- a/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-edit/rent-contract-edit.component.ts
+++ b/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-edit/rent-contract-edit.component.ts
@@ -374,9 +374,9 @@ export class RentContractEditComponent {
 			carenciaAluguel: formData.valueInfo.rentGrace,
 			prazoCarencia: +formData.valueInfo.gracePeriod,
 			dataInicioContrato: formData.contractInfo.startDate,
+			dataVencimentoContrato: formData.contractInfo.endDate,
 			prazoTotalContrato: this.data.prazoTotalContrato,
-			dataOcupacao: this.data.dataOcupacao,
-			//diaVencimentoAluguel: null,//+formData.contractInfo.dueDate,
+			dataOcupacao: formData.contractInfo.dataOcupacao,
 			dataVencimentoPrimeraParcela: formData.contractInfo.dueDate,
 			periodicidadeReajuste: this.data.periodicidadeReajuste,
 			lstImoveis: [

--- a/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-register/rent-contract-register.component.html
+++ b/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-register/rent-contract-register.component.html
@@ -760,6 +760,7 @@
 						defaultLabel="Selecione a(s) unidade(s)"
 						[showToggleAll]="false"
 						[showClear]="false"
+						(ngModelChange)="onChangeUnit($event)"
 					></p-multiSelect>
 
 					<ng-container
@@ -798,6 +799,7 @@
 				<button
 					pButton
 					pRipple
+					[disabled]="isUnidadeSelecionada"
 					type="button"
 					label="Continuar"
 					class="h-9 w-full"

--- a/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-register/rent-contract-register.component.ts
+++ b/IrisGestao/IrisSpa/src/app/pages/rent-contract/rent-contract-register/rent-contract-register.component.ts
@@ -6,6 +6,7 @@ import {
 	FormGroup,
 	Validators,
 } from '@angular/forms';
+import {formatDate} from '@angular/common';
 import { Router } from '@angular/router';
 import { first, fromEventPattern } from 'rxjs';
 import { RentContractService } from 'src/app/shared/services/rent-contract.service';
@@ -53,6 +54,7 @@ export class RentContractRegisterComponent {
 	registerRenterForm: FormGroup;
 
 	isRegistering = false;
+	isUnidadeSelecionada = true;
 
 	registerRenterVisible = false;
 
@@ -178,7 +180,7 @@ export class RentContractRegisterComponent {
 
 	ngOnInit() {
 		this.currentStep = 1;
-
+		
 		this.stepList = [
 			{
 				label: 'Informações do Contrato',
@@ -519,6 +521,7 @@ export class RentContractRegisterComponent {
 			};
 		} = this.registerForm.getRawValue();
 
+		let dataFim = formatDate(new Date(), 'yyyy-MM-ddThh:MM:ss', 'en');
 		const contractObj: ContratoAluguel = {
 			guidCliente: formData.contractInfo.locatario,
 			idTipoCreditoAluguel: formData.valuesInfo.creditarPara,
@@ -532,6 +535,7 @@ export class RentContractRegisterComponent {
 			carenciaAluguel: formData.valuesInfo.carencia,
 			prazoCarencia: +formData.valuesInfo.carenciaPrazo,
 			dataInicioContrato: formData.contractInfo.dataInicio,
+			dataVencimentoContrato: dataFim,
 			prazoTotalContrato: +formData.contractInfo.prazoTotalContrato, //???
 			dataOcupacao: formData.contractInfo.dataOcupacao,
 			//diaVencimentoAluguel: formData.contractInfo.dataVencimento,
@@ -751,6 +755,18 @@ export class RentContractRegisterComponent {
 				},
 			});
 		});
+	}
+
+	onChangeUnit(event: any) {
+		let unidades = [];
+		unidades = event;
+		const unitSelected = event?.guid;
+		console.log('onChangeUnit >> ' + unidades);
+		console.log('building2 >> ' + event?.value);
+		if(unidades && (Object.keys(unidades).length === 0))
+			this.isUnidadeSelecionada = true;
+		else
+			this.isUnidadeSelecionada = false;
 	}
 
 	updateLinkedPropertiesValidity() {

--- a/IrisGestao/IrisSpa/src/app/shared/models/contrato-aluguel.model.ts
+++ b/IrisGestao/IrisSpa/src/app/shared/models/contrato-aluguel.model.ts
@@ -13,6 +13,7 @@ export type ContratoAluguel = {
 	prazoCarencia: number;
 	prazoDesconto: number;
 	dataInicioContrato: string;
+	dataVencimentoContrato?: string;
 	prazoTotalContrato: number;
 	dataOcupacao: string;
 	//diaVencimentoAluguel: number;


### PR DESCRIPTION
Unidades locadas aparecem disponíveis e sem locatário no acesso pelo celular, sabe o que pode ser?
[Crítico] Ao cadastrar um novo contrato de aluguel, o título de receita gerado com o contrato ficou com o valor das faturas zerado. O mesmo erro se repete ao reajustar os contratos. Erro na geração automática de parcelas nos títulos de receita. [renato.s.almeida@outlook.com](mailto:renato.s.almeida@outlook.com), olha isso, por favor.

Ao editar a data final do contrato, o sistema não está salvando a nova data definida. No exemplo acima, a data final do contrato do Banco Santander foi editada para 31/08/2023, mas continua constando como 01/09/2023. [renato.s.almeida@outlook.com](mailto:renato.s.almeida@outlook.com), olha isso, por favor.