### PR TITLE
Edição de Despesas fechando entrega

### DIFF
--- a/IrisGestao/IrisSpa/src/app/pages/expense/expense-edit/expense-edit.component.html
+++ b/IrisGestao/IrisSpa/src/app/pages/expense/expense-edit/expense-edit.component.html
@@ -27,7 +27,7 @@
 					<input
 						id="name"
 						type="text"
-						[value]="imovel.tipo"
+						[value]='imovelTitulo.idCategoriaImovelNavigation?.nome'
 						aria-describedby="name-help"
 						maxlength="100"
 						pInputText
@@ -40,7 +40,7 @@
 					<input
 						id="name"
 						type="text"
-						[value]="imovel.nome"
+						[value]='imovelTitulo?.nome'
 						aria-describedby="name-help"
 						maxlength="100"
 						pInputText
@@ -49,12 +49,21 @@
 				</div>
 
 				<div class="photo-input">
-					<img src="../../../../assets/images/imovel.png" alt="edit-photo" />
+					<img
+						[src]="
+							croppedCover
+								? croppedCover
+								: defaultCoverImage ??
+								  '../../../../assets/images/imovel-placeholder.png'
+						"
+						alt="cover-photo"
+						class="coverPhoto"
+					/>
+
 				</div>
 
-				<h5 class="mt-4">Ed. José Maria Lopes</h5>
-				<p>{{ imovel.endereco }}</p>
-				<p><span class="icon file mr-2">&nbsp;</span>Edifício corporativo</p>
+				<p>{{ imovelTitulo.imovelEndereco?.[0]?.rua ?? '' }} -
+					{{ imovelTitulo.imovelEndereco?.[0]?.uf }}</p>
 			</section>
 			<form class="edit-form" [formGroup]="editForm" (ngSubmit)="onSubmit($event)">
 				<section class="aditional-data">


### PR DESCRIPTION
Editar título de despesa:
[Crítico] Ao editar os títulos de despesa, e clicar em “Continuar”, nada acontece e informações editadas não estão sendo salvas. 
Substituir “Receita” por “Despesa”. 
Substituir “Contrato” por “Despesa”. 
Nome e foto do edifício errados. (Ocorre também na edição dos títulos de receita) 
Campo exclusivo de receitas, retirar. Melhoria: Será tratada posteriormente.
Substituir “Locador” por “Locatário” e listar os locatários. Este campo deve ser não obrigatório ou ter alguma opção como “ - “, visto que algumas despesas não possuem locatários atrelados. 